### PR TITLE
Mailing Fixes

### DIFF
--- a/app/helpers/timestamp_helper.rb
+++ b/app/helpers/timestamp_helper.rb
@@ -4,9 +4,9 @@ module TimestampHelper
     @end   = week.starts_at.end_of_week(start_day = :saturday)
 
     if @start.month == @end.month
-      return "#{@start.strftime('%b %-d')} - #{@end.strftime('%-d, %Y')}"
+      return "#{@start.strftime('%b %-d')} - #{@end.strftime('%-d')}"
     elsif @start.year == @end.year
-      return "#{@start.strftime('%b %-d')} - #{@end.strftime('%b %-d, %Y')}"
+      return "#{@start.strftime('%b %-d')} - #{@end.strftime('%b %-d')}"
     else
       return "#{@start.strftime('%b %-d, %y')} - #{@end.strftime('%b %-d, %y')}"
     end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,6 +1,9 @@
 class UserMailer < ApplicationMailer
+  helper :timestamp
+
   def assignment_reminder(assignment)
-    @employee = assignment.employee
+    @assignment = assignment
+    @employee = @assignment.employee
     @current_office = @employee.office
 
     mail(to: @employee.email, subject: "Kitchen Duties Reminder")

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,6 +1,4 @@
 class UserMailer < ApplicationMailer
-  helper :timestamp
-
   def assignment_reminder(assignment)
     @assignment = assignment
     @employee = @assignment.employee

--- a/app/services/sends_assignment_reminders.rb
+++ b/app/services/sends_assignment_reminders.rb
@@ -1,11 +1,11 @@
 class SendsAssignmentReminders
-  def initialize
-    @week = Week.upcoming.first
-  end
-
   def call
-    Assignment.where(week: @week).find_each do |assignment|
-      UserMailer.assignment_reminder(assignment).deliver
+    Office.find_each do |office|
+      @week = office.weeks.upcoming.second
+
+      Assignment.where(week: @week).find_each do |assignment|
+        UserMailer.assignment_reminder(assignment).deliver
+      end
     end
   end
 end

--- a/app/views/user_mailer/assignment_reminder.html.erb
+++ b/app/views/user_mailer/assignment_reminder.html.erb
@@ -1,7 +1,7 @@
 
 <p>Hello <%= @employee.first_name %>,  </p>
 
-<p>This is a reminder that you are assigned to kitchen duties from <%= print_date(@assignment.week) %>. </p>
+<p>This is a reminder that you are assigned to kitchen duties next week (<%= @assignment.week.starts_at.strftime('%B %-d') %>). </p>
 
 <p>You can view the schedule <%= link_to "here", office_assignments_url(@current_office) %>. </p>
 

--- a/app/views/user_mailer/assignment_reminder.html.erb
+++ b/app/views/user_mailer/assignment_reminder.html.erb
@@ -1,7 +1,7 @@
 
 <p>Hello <%= @employee.first_name %>,  </p>
 
-<p>This is a reminder that you are assigned to kitchen duties this week. </p>
+<p>This is a reminder that you are assigned to kitchen duties from <%= print_date(@assignment.week) %>. </p>
 
 <p>You can view the schedule <%= link_to "here", office_assignments_url(@current_office) %>. </p>
 

--- a/app/views/user_mailer/assignment_reminder.text.erb
+++ b/app/views/user_mailer/assignment_reminder.text.erb
@@ -1,6 +1,6 @@
 Hello <%= @employee.first_name %>,
 
-This is a reminder that you are assigned to kitchen duties this week. 
+This is a reminder that you are assigned to kitchen duties from <%= print_date(@assignment.week) %>. 
 
 You can view the schedule here: <%= office_assignments_url(@current_office) %>
 

--- a/app/views/user_mailer/assignment_reminder.text.erb
+++ b/app/views/user_mailer/assignment_reminder.text.erb
@@ -1,6 +1,6 @@
 Hello <%= @employee.first_name %>,
 
-This is a reminder that you are assigned to kitchen duties from <%= print_date(@assignment.week) %>. 
+This is a reminder that you are assigned to kitchen duties next week (<%= @assignment.week.starts_at.strftime('%B %-d') %>). 
 
 You can view the schedule here: <%= office_assignments_url(@current_office) %>
 

--- a/lib/tasks/mail_tasks.rake
+++ b/lib/tasks/mail_tasks.rake
@@ -2,7 +2,7 @@ namespace :mail_tasks do
   desc "rake task for heroku schedule to send out the weekly notifications."
   task send_weekly_notifications: :environment do
     # Heroku scheduler only allows for daily tasks so we conditionally send
-    SendsAssignmentReminders.new.call if Time.now.sunday?
+    SendsAssignmentReminders.new.call if Time.now.thursday?
   end
 
   task send_weekly_notifications_now: :environment do


### PR DESCRIPTION
Fixes the problem with sending the previous weeks assignment notification, switched the assignment reminders to thursday, and changed the email to include the date of assignment

